### PR TITLE
Logic changes

### DIFF
--- a/mmr_overworldmap_bladefangft_tekky/locations/dungeons.json
+++ b/mmr_overworldmap_bladefangft_tekky/locations/dungeons.json
@@ -16,17 +16,14 @@
         "item_count": 1,
         "capture_item": true,
         "access_rules": [
-          "bow"
+          "dekumask",
+          "hookshot"
         ]
       },
       {
         "name": "Compass",
         "item_count": 1,
         "capture_item": true,
-        "access_rules": [
-          "dekumask",
-          "hookshot"
-        ]
       },
       {
         "name": "Boss Key",
@@ -116,7 +113,9 @@
         "item_count": 1,
         "capture_item": true,
         "access_rules": [
-          "$explosives"
+          "$explosives",
+          "[goronmask]",
+          "[bow],[firearrow]"
         ]
       },
       {
@@ -227,7 +226,7 @@
         "item_count": 1,
         "capture_item": true,
         "access_rules": [
-          "$explosives,bow"
+          "$explosives"
         ]
       },
       {
@@ -259,7 +258,7 @@
         "item_count": 1,
         "capture_item": true,
         "access_rules": [
-          "bow,lightarrow"
+          "bow,lightarrow,zoramask"
         ]
       },
       {
@@ -277,6 +276,14 @@
         "access_rules": [
           "$ISTT_access"
         ]
+      },
+      {
+        "name": "Giant's Mask",
+        "item_count": 1,
+        "capture_item": true,
+        "access_rules": [
+          "$ISTT_access"
+          ]
       },
       {
         "name": "Twinmold",
@@ -313,6 +320,7 @@
             "name": "Hookshot",
             "access_rules": [
               "goronmask,bow",
+              "goronmask,dekumask",
               "hookshot,bow",
               "hookshot,dekumask"
             ],
@@ -398,7 +406,7 @@
           {
             "name": "Guard Room 100 Rupees",
             "access_rules": [
-              "everything_on"
+              "hookshot,everything_on"
             ],
             "sections": [
               {

--- a/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
+++ b/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
@@ -1793,7 +1793,10 @@
                   {
                     "name": "Ikana Map",
                     "item_count": 1,
-                    "capture_item": true
+                    "capture_item": true,
+                    "access_rules": [
+                      "[garomask],[hookshot]"
+                    ]
                   }
                 ],
                 "map_locations": [

--- a/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
+++ b/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
@@ -665,9 +665,6 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "[hookshot]",
-                      "[beans],[$has_bottle]",
-                      "[beans],[storm]"
                       "[dekumask]"
                     ]
                   }

--- a/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
+++ b/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
@@ -212,8 +212,8 @@
                     "capture_item": true,
                     "chest_unopened_img": "images/HP.png",
                     "chest_opened_img": "images/HP_grey.png"
-                  },/*
-                  {
+                  },
+                  /*{
                     "name": "All-Night Mask",
                     "item_count": 1,
                     "capture_item": true,
@@ -1147,7 +1147,7 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "dekumask,landdeed,"
+                      "dekumask,landdeed",
                       "[goronmask]"
                     ]
                   }
@@ -1437,7 +1437,7 @@
               {
                 "name": "Hot Spring 20 Rupees",
                 "access_rules": [
-                  "bow,firearrow,$explosives,everything_on"
+                  "bow,firearrow,$explosives,everything_on",
                   "$explosives,§hotspring_access,everything_on"
                 ],
                 "sections": [

--- a/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
+++ b/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
@@ -212,7 +212,7 @@
                     "capture_item": true,
                     "chest_unopened_img": "images/HP.png",
                     "chest_opened_img": "images/HP_grey.png"
-                  },
+                  },/*
                   {
                     "name": "All-Night Mask",
                     "item_count": 1,

--- a/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
+++ b/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
@@ -665,10 +665,10 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "dekumask",
                       "[hookshot]",
                       "[beans],[$has_bottle]",
                       "[beans],[storm]"
+                      "[dekumask]"
                     ]
                   }
                 ],
@@ -1028,8 +1028,8 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "[beans],[$has_bottle],everything_on",
-                      "[beans,[storm],everything_on",
+                      "[hookshot],beans,$has_bottle,everything_on",
+                      "[hookshot],beans,storm,everything_on",
                       "hookshot,everything_on"
                     ]
                   }
@@ -1077,8 +1077,8 @@
                   }
                 ],
                 "access_rules": [
-                  "dekumask,beans,[$has_bottle]",
-                  "dekumask,beans,[storm]"
+                  "dekumask,beans,$has_bottle",
+                  "dekumask,beans,storm,[$has_bottle]"
                 ],
                 "map_locations": [
                   {
@@ -1100,7 +1100,7 @@
                 "access_rules": [
                   "[dekuprincess],[bow]",
                   "[dekuprincess],[zoramask]",
-                  "[dekuprincess],odolwaremain"
+                  "[dekuprincess],odolwaremains"
                 ],
                 "map_locations": [
                   {
@@ -1147,8 +1147,7 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "dekumask,landdeed",
-                      "[goronmask]"
+                      "[dekumask],[landdeed],goronmask"
                     ]
                   }
                 ],
@@ -1291,7 +1290,8 @@
         "color": "#f32a30",
         "access_rules": [
           "bow,$explosives",
-          "bow,[goronmask]",
+          "bow,goronmask,[$explosives]",
+          "bow,goronmask,[firearrow]",
           "bow,firearrow"
         ],
         "children": [
@@ -1438,7 +1438,7 @@
                 "name": "Hot Spring 20 Rupees",
                 "access_rules": [
                   "bow,firearrow,$explosives,everything_on",
-                  "$explosives,§hotspring_access,everything_on"
+                  "$explosives,$hotspring_access,everything_on"
                 ],
                 "sections": [
                   {
@@ -1478,7 +1478,7 @@
               {
                 "name": "Goron Racetrack Bottle",
                 "access_rules": [
-                  "goronmask,gohtremains",
+                  "goronmask,gohtremains"
                 ],
                 "sections": [
                   {
@@ -2331,7 +2331,7 @@
             "name": "Ikana Canyon",
             "access_rules": [
               "garomask,hookshot",
-              "[gibdomask],hookshot"
+              "gibdomask,hookshot,[garomask]"
             ],
             "children": [
               {
@@ -2524,7 +2524,7 @@
                         "name": "Elegy of Emptiness",
                         "access_rules": [
                           "powderkeg,goronmask",
-                          "[lightarrow]"
+			                    "lightarrow,[powderkeg],[goronmask]"
                         ],
                         "chest_opened_img": "images/grey_note_check.png",
                         "chest_unopened_img": "images/grey_note.png",
@@ -2554,24 +2554,35 @@
               {
                 "name": "Stone Tower",
                 "access_rules": [
-                  "$STT_access,bow,lightarrow,beans,$has_bottle",
-                  "$STT_access,bow,lightarrow,beans,[storm]"
+                  "epona,$STT_access",
                 ],
                 "sections": [
                   {
                     "name": "100 Rupees",
                     "item_count": 1,
-                    "capture_item": true
+                    "capture_item": true,
+                    "access_rules": [
+                      "everything_on,bow,lightarrow,beans,$has_bottle",
+                      "everything_on,bow,lightarrow,beans,storm,[$has_bottle]"
+                    ],
                   },
                   {
                     "name": "Bombchus",
                     "item_count": 1,
-                    "capture_item": true
+                    "capture_item": true,
+                    "access_rules": [
+                      "everything_on,bow,lightarrow,beans,$has_bottle",
+                      "everything_on,bow,lightarrow,beans,storm,[$has_bottle]"
+                    ],
                   },
                   {
                     "name": "Magic Bean ",
                     "item_count": 1,
-                    "capture_item": true
+                    "capture_item": true,
+                    "access_rules": [
+                      "everything_on,bow,lightarrow,beans,$has_bottle",
+                      "everything_on,bow,lightarrow,beans,storm,[$has_bottle]"
+                    ],
                   }
                 ],
                 "map_locations": [

--- a/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
+++ b/mmr_overworldmap_bladefangft_tekky/locations/overworld.json
@@ -212,7 +212,7 @@
                     "capture_item": true,
                     "chest_unopened_img": "images/HP.png",
                     "chest_opened_img": "images/HP_grey.png"
-                  }/*,
+                  },
                   {
                     "name": "All-Night Mask",
                     "item_count": 1,
@@ -241,7 +241,7 @@
                 "item_count": 1,
                 "capture_item": true,
                 "access_rules": [
-                  "romanimask,kafeimask,mamaletter"
+                  "kafeimask,mamaletter"
                 ]
               },
               {
@@ -392,8 +392,7 @@
                 "item_count": 1,
                 "capture_item": true,
                 "access_rules": [
-                  "[bombercode],$explosives",
-                  "dekumask,$explosives"
+                  "[$has_ranged],$explosives"
                 ]
               },
               {
@@ -481,7 +480,7 @@
                 "item_count": 1,
                 "capture_item": true,
                 "access_rules": [
-                  "dekumask", "bombercode"
+                  "$has_ranged"
                 ]
               }
             ],
@@ -518,9 +517,11 @@
                 "item_count": 1,
                 "capture_item": true,
                 "access_rules": [
-                  "dekumask,sonata,goronmask,$explosives",
+                  "dekumask,sonata,goronmask",
+                  "dekumask,sonata,$explosives",
                   "goronmask,lullaby",
-                  "zoramask,newwave,goronmask,$explosives"
+                  "zoramask,newwave,goronmask",
+                  "zoramask,newwave,$explosives"
                 ]
               }
             ],
@@ -540,8 +541,7 @@
                 "item_count": 1,
                 "capture_item": true,
                 "access_rules": [
-                  "wallet,[bombercode]",
-                  "wallet,dekumask"
+                  "wallet,$has_ranged"
                 ]
               }
             ],
@@ -665,9 +665,10 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "hookshot",
-                      "beans,[$has_bottle]",
-                      "beans,[storm]"
+                      "dekumask",
+                      "[hookshot]",
+                      "[beans],[$has_bottle]",
+                      "[beans],[storm]"
                     ]
                   }
                 ],
@@ -721,7 +722,10 @@
               {
                 "name": "Great Bay Map",
                 "item_count": 1,
-                "capture_item": true
+                "capture_item": true,
+                "access_rules":[
+                  "[epona]"
+                ]
               }
             ],
             "map_locations": [
@@ -796,10 +800,7 @@
               {
                 "name": "Dog Race HP",
                 "item_count": 1,
-                "capture_item": true,
-                "access_rules": [
-                    "[maskoftruth]"
-                ]
+                "capture_item": true
               },
               {
                 "name": "Bunny Hood",
@@ -890,7 +891,7 @@
                 ],
                 "sections": [
                   {
-                    "name": "Get it",
+                    "name": "Get in the grotto",
                     "item_count": 1,
                     "capture_item": true
                   }
@@ -917,7 +918,12 @@
                   {
                     "name": "Snowhead Map",
                     "item_count": 1,
-                    "capture_item": true
+                    "capture_item": true,
+                    "access_rules":[
+                      "[bow],[goronmask]",
+                      "[bow],[$explosives]",
+                      "[bow],[firearrow]"
+                    ]
                   }
                 ],
                 "map_locations": [
@@ -933,7 +939,7 @@
           {
             "name": "South Swamp",
             "access_rules": [
-              "bow",
+              "bow,dekumask",
               "zoramask",
               "$has_bottle"
             ],
@@ -962,8 +968,7 @@
               {
                 "name": "Swamp Grotto",
                 "access_rules": [
-                  "dekumask,everything_on",
-                  "zoramask,everything_on"
+                  "everything_on",
                 ],
                 "sections": [
                   {
@@ -1023,8 +1028,8 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "beans,$has_bottle,everything_on",
-                      "beans,storm,everything_on",
+                      "[beans],[$has_bottle],everything_on",
+                      "[beans,[storm],everything_on",
                       "hookshot,everything_on"
                     ]
                   }
@@ -1093,8 +1098,8 @@
                   }
                 ],
                 "access_rules": [
-                  "[dekuprincess],bow",
-                  "[dekuprincess],zoramask",
+                  "[dekuprincess],[bow]",
+                  "[dekuprincess],[zoramask]",
                   "[dekuprincess],odolwaremain"
                 ],
                 "map_locations": [
@@ -1126,8 +1131,7 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "$has_ranged,$has_bottle,pictobox",
-                      "@Deku Palace,pictobox"
+                      "pictobox"
                     ]
                   },
                   {
@@ -1143,7 +1147,8 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "[dekumask],[landdeed],goronmask"
+                      "dekumask,landdeed,"
+                      "[goronmask]"
                     ]
                   }
                 ],
@@ -1285,10 +1290,9 @@
         "name": "Snowhead Mountain",
         "color": "#f32a30",
         "access_rules": [
-          "[bow],$explosives,hotspring",
-          "[bow],goronmask,hotspring",
           "bow,$explosives",
-          "bow,goronmask"
+          "bow,[goronmask]",
+          "bow,firearrow"
         ],
         "children": [
           {
@@ -1354,7 +1358,7 @@
                   }
                 ],
                 "access_rules": [
-                  "goronmask,sticks"
+                  "goronmask,[sticks]"
                 ],
                 "map_locations": [
                   {
@@ -1368,7 +1372,7 @@
               {
                 "name": "Frog Choir HP",
                 "access_rules": [
-                  "gohtremains,@Woodfall Temple,newwave,hookshot,zoramask"
+                  "dongero,gohtremains,odolwaremains,gyorgremains,[twinmoldremains]"
                 ],
                 "sections": [
                   {
@@ -1434,6 +1438,7 @@
                 "name": "Hot Spring 20 Rupees",
                 "access_rules": [
                   "bow,firearrow,$explosives,everything_on"
+                  "$explosives,§hotspring_access,everything_on"
                 ],
                 "sections": [
                   {
@@ -1473,7 +1478,7 @@
               {
                 "name": "Goron Racetrack Bottle",
                 "access_rules": [
-                  "goronmask,gohtremains"
+                  "goronmask,gohtremains",
                 ],
                 "sections": [
                   {
@@ -1626,7 +1631,7 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "everything_on"
+                      "$explosives,everything_on"
                     ]
                   }
                 ],
@@ -1674,7 +1679,7 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "hookshot,[lensoftruth]"
+                      "hookshot"
                     ]
                   }
                 ],
@@ -1836,7 +1841,7 @@
               {
                 "name": "North Ledge HP",
                 "access_rules": [
-                  "hookshot,beans,[$has_bottle]",
+                  "hookshot,beans,$has_bottle",
                   "hookshot,beans,[storm]"
                 ],
                 "sections": [
@@ -1976,7 +1981,7 @@
                     "item_count": 1,
                     "capture_item": true,
                     "access_rules": [
-                      "goronmask,mountaindeed"
+                      "goronmask,mountaindeed,dekumask"
                     ]
                   },
                   {
@@ -2036,7 +2041,7 @@
               {
                 "name": "Great Bay Ledge Chest 2",
                 "access_rules": [
-                  "hookshot,everything_on"
+                  "[dekumask],hookshot,everything_on"
                 ],
                 "sections": [
                   {
@@ -2133,7 +2138,7 @@
               {
                 "name": "Shiro",
                 "access_rules": [
-                  "epona,bottle,lensoftruth"
+                  "epona,$has_bottle,lensoftruth"
                 ],
                 "sections": [
                   {
@@ -2310,7 +2315,7 @@
                   }
                 ],
                 "access_rules": [
-                  "sonata,bow"
+                  "sonata,[bow]"
                 ],
                 "map_locations": [
                   {
@@ -2326,7 +2331,7 @@
             "name": "Ikana Canyon",
             "access_rules": [
               "garomask,hookshot",
-              "gibdomask,hookshot"
+              "[gibdomask],hookshot"
             ],
             "children": [
               {
@@ -2519,7 +2524,7 @@
                         "name": "Elegy of Emptiness",
                         "access_rules": [
                           "powderkeg,goronmask",
-                          "bow,lightarrow"
+                          "[lightarrow]"
                         ],
                         "chest_opened_img": "images/grey_note_check.png",
                         "chest_unopened_img": "images/grey_note.png",
@@ -2549,7 +2554,7 @@
               {
                 "name": "Stone Tower",
                 "access_rules": [
-                  "$STT_access,bow,lightarrow,beans,[$has_bottle]",
+                  "$STT_access,bow,lightarrow,beans,$has_bottle",
                   "$STT_access,bow,lightarrow,beans,[storm]"
                 ],
                 "sections": [


### PR DESCRIPTION
Refinements to map tracker logic to be faithful to logic in use by the randomiser.

Several alternate ways marked as sequence breaks.

Added missing Giant's Mask Check

Fixed missing hookshot requirement for "PF Guard Room 100 rupees"

Fixed access rules for Stone Tower Temple Dungeon as well as chests outside.